### PR TITLE
Remove extra `fi` that breaks syntax

### DIFF
--- a/usr/bin/sfos-upgrade
+++ b/usr/bin/sfos-upgrade
@@ -393,7 +393,6 @@ then
       echo "Disabling OpenRepos\' repository $i failed: aborting!" | tee -a "$logfile"
       exit 6
     fi
-  fi
   done
   echo | tee -a "$logfile"
 fi


### PR DESCRIPTION
sfos-upgrade 2.0 failed on this line, when I tried

> Do you want to upgrade SailfishOS from 3.0.0.8 to 3.0.1.11? (Y/N) Y