### PR TITLE
changed to detect installed version via regular expressions.

### DIFF
--- a/usr/bin/sfos-upgrade
+++ b/usr/bin/sfos-upgrade
@@ -101,7 +101,7 @@ then
   exit 3
 fi
 
-installed_release="$(version | grep '[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*' -o)"
+installed_release="$(version | grep -o ' [0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*' | cut -c 2- | sed -n '1p')"
 if [ -z "$*" ]
 then
   set_ssu=""

--- a/usr/bin/sfos-upgrade
+++ b/usr/bin/sfos-upgrade
@@ -101,7 +101,7 @@ then
   exit 3
 fi
 
-installed_release="$(version | rev | cut -s -f 2 -d ' ' | rev)"
+installed_release="$(version | grep '[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*' -o)"
 if [ -z "$*" ]
 then
   set_ssu=""


### PR DESCRIPTION
works when the version is like 1.2.3.4, to fix when `version` reports architechture: `SailfishOS 1.0.8.19 (Tahkalampi) (armv7hl)`