### PR TITLE
Allow to override the "omitting stop release prevention" again

### DIFF
--- a/rpm/sfos-upgrade.spec
+++ b/rpm/sfos-upgrade.spec
@@ -1,6 +1,6 @@
 Name:          sfos-upgrade
 Summary:       Scripts for safe and automated upgrading of SailfishOS with logging
-Version:       3.7.0
+Version:       3.7.1
 # Stop evaluating the Release tag content (only set it) and cease including it in git tags since v3.6.0, 
 # in order to satisfy OBS' git_tar.  Consequently switch to a three field semantic versioning scheme for
 # releases and their git tags.
@@ -9,7 +9,7 @@ Version:       3.7.0
 # But the Release tag is now (ab)used to merely indicate the estimated release quality by setting it
 # to {alpha, beta, stable} with a natural number >= 1 directly appended (e.g. "beta3").  Note that
 # no other identifiers shall be used.
-Release:       stable4
+Release:       stable5
 Group:         System/Base
 Distribution:  SailfishOS
 Vendor:        olf

--- a/usr/bin/sfos-upgrade
+++ b/usr/bin/sfos-upgrade
@@ -2,7 +2,7 @@
 set -euC -o posix  # Omitting -f (aka -o noglob), because bash 3.2.57(1)-release does not perform a set +f (or +o noglob; plus setopt is not built-in) correctly, which would be needed later!
 
 # Switched to use bash since version 2.1 of this script (in its first line), as this ensures that "-o pipefail"
-# (in line 618) is available, after checking that bash seems to be present in mer-core at least since 2011-10-04
+# (in line 619) is available, after checking that bash seems to be present in mer-core at least since 2011-10-04
 # (see https://git.sailfishos.org/mer-core/bash / https://git.merproject.org/mer-core/bash ) and consequently in
 # SailfishOS since its beginnings (checked v1.0.0.5 per
 # curl https://releases.sailfishos.org/sources/sailfish-1.0.0.5-oss.tar.bz2 | tar -tv | fgrep 'bash' , as no earlier
@@ -226,13 +226,14 @@ else
         l?)
           echo "Notice: Upgrading from $installed_release to $upgrade_release would omit installing $stop_release as a stop release!" >&2
           if [ -n "$set_ssu" ]
-          then echo "Thus upgrading to $stop_release instead." >&2
+          then
+            echo "Thus upgrading to $stop_release instead." >&2
+            upgrade_release="$stop_release"
           else
-            echo -n "Set SSU to $stop_release before upgrading (a negative reply aborts)?" >&2
+            echo "Warning: Doing so will likely break this SailfishOS installation, unfortunately often only subtly so the issues caused might be observed way later!" >&2
+            echo -n "Do you really want to continue?" >&2
             askyes >&2
-            set_ssu="yes"
           fi
-          upgrade_release="$stop_release"
           echo >&2
           break
           ;;


### PR DESCRIPTION
Reintroduce the ability to override the "omitting stop release prevention" for upgrades in "SSU mode" (to satisfy feature request #42).