### PR TITLE
sfos-upgrade: askyes: make default action upper case

### DIFF
--- a/usr/bin/sfos-upgrade
+++ b/usr/bin/sfos-upgrade
@@ -38,7 +38,7 @@ askyes ()
 {
   # All its regular output goes to STDOUT (only warnings go to STDERR)
   # and it exits (instead of returning) when the user asks to abort.
-  echo -n " (Y/N) "
+  echo -n " (y/N) "
   read yn
   retcode=1
   case "$yn" in


### PR DESCRIPTION
the convention is that the default action is denoted by an upper case
character and the other options are a lower case character