### PR TITLE
post_sfos-upgrade: Support arbitrary usernames,

### DIFF
--- a/usr/bin/post_sfos-upgrade
+++ b/usr/bin/post_sfos-upgrade
@@ -35,8 +35,9 @@ then
   done
   echo
 fi
-rm -f /home/nemo/.cache/sailfish-osupdateservice/os-info /home/nemo/.cache/store-client/os-info
-rm -f /home/defaultuser/.cache/sailfish-osupdateservice/os-info /home/defaultuser/.cache/store-client/os-info
+# See https://github.com/sailfishos/udisks2/commit/bcc6437ff35a3cc1e8c4777ee80d85a9c112e63e#diff-be2415d9a1095d0aa0d9dc7977c388a7ab5bb3ff7b3e4c38713062bd03165cee
+primuser="$(loginctl list-sessions | fgrep seat0 | tr -s ' ' | cut -d ' ' -f 4)"
+rm -f "/home/${primuser}/.cache/sailfish-osupdateservice/os-info" "/home/${primuser}/.cache/store-client/os-info"
 
 if command -v zypper > /dev/null 2>&1
 then

--- a/usr/bin/sfos-upgrade
+++ b/usr/bin/sfos-upgrade
@@ -429,6 +429,9 @@ POWER_SUPPLY_CHARGE_NOW=""
 POWER_SUPPLY_CHARGE_FULL=""
 POWER_SUPPLY_CHARGE_FULL_DESIGN=""
 # References: https://www.kernel.org/doc/Documentation/power/power_supply_class.txt and https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-power
+# An alternative method would be https://github.com/sailfishos/btrfs-balancer/commit/a9841fee4194383364324aebc501b96d94ed3e27#
+# but that is clumsy and MCE's D-Bus calls are not really well documented (do they provide POWER_SUPPLY_CHARGE_FULL and POWER_SUPPLY_CHARGE_FULL_DESIGN?).
+# Hence rather rely on sysfs.
 battery_info=""
 battery_path="/sys/class/power_supply/*battery*"
 for battery_uevents in $battery_path


### PR DESCRIPTION
… but `loginctl list-sessions` may not work on really old SailfishOS releases.  Would have to check which version of `systemd` SailfishOS 1.0.0.5 uses and if this provides `loginctl list-sessions`.

Done: 
- loginctl exists since systemd 183 (the udev merge release; was systemd-loginctl before systemd 183), see https://github.com/systemd/systemd/blob/main/NEWS
- But `loginctl list` mentioned for systemd 232 (2016-11-03) does not exist (any more?), but maybe this addresses all `list-*` commands.
- systemd 209 (2014-02-20) introduced the --no-legend option.
- But only systemd 248 (2021-03-30) added the --no-page option!

O.K., by looking at the commit history of the `loginctl` man page, its command `list-sessions` has been there when the rename (see first bullet point) per systemd 183 occurred.

Looking at the commit history of `loginctl.c`:
- The `list-sessions` command has been there since its inception.
- Its output format is the same at least since April 2012 (presumably since its inception): https://github.com/systemd/systemd/commit/cc1368e3b3585ab822d76e00945ed4c064047530#diff-1d64ac6e58816e3bbf6f66cf77fd7f62c8b5d271c538b4e3bd0686fa21d29786R130
- No command means `list-sessions`!

---------------------------------------------------------------

Public SailfishOS releases appear to have started with systemd 185 or 187: https://github.com/sailfishos/systemd/commit/8141929e7c04552271052a77b24e78805789ce3c#diff-e26982ec487a21aa69f33007a00f6ebd8ccab3b4501aff1f7dd0808dccb2f8fa