### PR TITLE
Use `df` POSIXly / in a portable manner …

### DIFF
--- a/usr/bin/sfos-upgrade
+++ b/usr/bin/sfos-upgrade
@@ -1,10 +1,13 @@
 #!/bin/bash
 set -euC  # Omitting -f (aka -o noglob), because bash 3.2.57(1)-release does not perform a set +f (or +o noglob; plus setopt is not built-in) correctly, which would be needed later!
-export POSIXLY_CORRECT=1
 export LC_ALL=POSIX  # For details see https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html#tag_08_02
+export POSIXLY_CORRECT=1  # Also necessary for a sane `df` output, see https://github.com/Olf0/sfos-upgrade/issues/73 
+export BLOCKSIZE=512      # For `df` et al, see POSIX's `df` man-page and man-page for GNU `df`
+export BLOCK_SIZE=512     # For `df` et al, see man-page for GNU `df`
+export DF_BLOCK_SIZE=512  # For `df` et al, see mmn-page for GNU `df`
 
 # Switched to use bash since version 2.1 of this script (in its first line), as this ensures that "-o pipefail"
-# (in line 644) is available, after checking that bash seems to be present in mer-core at least since 2011-10-04
+# (in line 655) is available, after checking that bash seems to be present in mer-core at least since 2011-10-04
 # (see https://git.sailfishos.org/mer-core/bash / https://git.merproject.org/mer-core/bash ) and consequently in
 # SailfishOS since its beginnings (checked v1.0.0.5 per
 # curl https://releases.sailfishos.org/sources/sailfish-1.0.0.5-oss.tar.bz2 | tar -tv | fgrep 'bash' , as no earlier
@@ -409,7 +412,8 @@ then
     exit 5
   fi
 else
-  free_space="$(df -k / | sed -n '2p' | rev | grep '^/ ' | tr -s ' ' | cut -s -f 3 -d ' ' | rev)"
+  # Formula "(<df in 0.5 K blocks> + 1) / 2) is slightly off for negative values (which `df` may really emit): It would then have to be "<df in 0.5 K blocks> - 1) / 2)" instead.
+  free_space="$(expr \( "$(df -P / | sed -n '2p' | rev | grep '^/ ' | tr -s ' ' | cut -s -f 3 -d ' ' | rev)" '+' 1 \) '/' 2)"
   # Note that in contrast to upgrading at the GUI, the RPMs for upgrading are not all downloaded first (and installed after booting into the system-update mode),
   # but downloaded and installed one by one, hence requiring much less space on persistent storage (i.e., the root filesystem) for upgrading.
   # OTOH, be aware that the download sizes Jolla mentions in their release notes are only valid for upgrading from the direct predecessor release,


### PR DESCRIPTION
… which works for both, GNU's `df` (part of gnu-coreutils package) and busybox's df (activated by the busybox-symlink-df package), plus presumably other POSIX compatible 'df' implementations. Fixes https://github.com/Olf0/sfos-upgrade/issues/73